### PR TITLE
fix(packages): init packages so as not to break loop in taskfile

### DIFF
--- a/packages/babel/package-lock.json
+++ b/packages/babel/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "babel",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "babel",
+  "version": "1.0.0",
+  "description": "Babel Compiler --------------",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/jest/package-lock.json
+++ b/packages/jest/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "jest",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jest",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/mocha/package-lock.json
+++ b/packages/mocha/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "mocha",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "mocha",
+  "version": "1.0.0",
+  "description": "open questions?  ---------------------",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
Before this, doing `npm install` in the global project created an infinite loop.

This is because some package directories only had a `readme` file and not a `package.json` file. So npm would find the nearest `package.json` file, which was the global `package.json` file, and run `npm install` in it, etc. etc. ad infinitum :)

