### PR TITLE
docs(contributing): accurate path in instructions

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Consume in project by configuring the compiler dist in options.file.
             "compiler": {
                 "bit.envs/compilers/typescript@3.1.0": {
                     "options": {
-                        "file": "[path-to-typescript-dist]"
+                        "file": "[path-to-envs-repo]/packages/ts-compiler/dist/src/index.js"
                     }
                 }
             }


### PR DESCRIPTION
## Proposed Changes
I just fixed the path in the ts-compiler to be more accurate for easier copy-pastability.