### PR TITLE
add react-native compiler with test

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -128,6 +128,49 @@
         "origin": "AUTHORED",
         "exported": true
     },
+    "bit.envs/compilers/react-native@0.0.3": {
+        "files": [
+            {
+                "relativePath": "packages/react-native/.babelrc",
+                "test": false,
+                "name": ".babelrc"
+            },
+            {
+                "relativePath": "packages/react-native/README.md",
+                "test": false,
+                "name": "README.md"
+            },
+            {
+                "relativePath": "packages/react-native/index.ts",
+                "test": false,
+                "name": "index.ts"
+            },
+            {
+                "relativePath": "packages/react-native/package.json",
+                "test": false,
+                "name": "package.json"
+            },
+            {
+                "relativePath": "packages/react-native/test/compile-react.spec.ts",
+                "test": false,
+                "name": "compile-react.spec.ts"
+            },
+            {
+                "relativePath": "packages/react-native/test/component-examples.ts",
+                "test": false,
+                "name": "component-examples.ts"
+            },
+            {
+                "relativePath": "packages/react-native/tsconfig.json",
+                "test": false,
+                "name": "tsconfig.json"
+            }
+        ],
+        "mainFile": "packages/react-native/index.ts",
+        "trackDir": "packages/react-native",
+        "origin": "AUTHORED",
+        "exported": true
+    },
     "bit.envs/compilers/react-typescript@3.1.25": {
         "files": [
             {
@@ -176,7 +219,7 @@
         "origin": "AUTHORED",
         "exported": true
     },
-    "bit.envs/compilers/react@1.0.8": {
+    "bit.envs/compilers/react@1.0.9": {
         "files": [
             {
                 "relativePath": "packages/react/.babelrc",

--- a/.taskfile
+++ b/.taskfile
@@ -17,7 +17,7 @@ function clean(){
 }
 
 function run_test(){
-    declare -a testFolders=(common ts-compiler react-typescript react)
+    declare -a testFolders=(common react react-native react-typescript ts-compiler)
     cd packages
     for fold in "${testFolders[@]}"; do
     cd $fold

--- a/package.json
+++ b/package.json
@@ -96,6 +96,26 @@
           "@types/mocha": "^5.2.7",
           "bit-bin": "14.6.0"
         }
+      },
+      "compilers/react": {
+        "dependencies": {
+          "bit-bin": "-"
+        },
+        "devDependencies": {
+          "@types/node": "+",
+          "@types/mocha": "^5.2.7",
+          "bit-bin": "^14.7.1"
+        }
+      },
+      "compilers/react-native": {
+        "dependencies": {
+          "bit-bin": "-"
+        },
+        "devDependencies": {
+          "@types/node": "+",
+          "@types/mocha": "^5.2.7",
+          "bit-bin": "^14.7.1"
+        }
       }
     }
   }

--- a/packages/react-native/.babelrc
+++ b/packages/react-native/.babelrc
@@ -1,0 +1,5 @@
+{
+    "presets": [
+        "module:metro-react-native-babel-preset"
+    ]
+}

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -1,0 +1,25 @@
+# Babel-based transpiling environment for React Native components
+
+Bit build enviroment for transpiling React Native components using Bit.
+
+## How to use?
+
+Import the environment.
+
+```bash
+bit import bit.envs/compilers/react-native -c
+```
+
+Then build using [bit build](https://docs.bitsrc.io/docs/cli-build.html).
+
+```bash
+bit build
+```
+
+## Reconfiguring this environment
+
+In case the configuration presets in the `.babelrc` file of this component are not well suited to your needs, follow [these steps](https://discourse.bit.dev/t/can-i-modify-a-build-test-environments/28) to modify it.
+
+## Got any issues or questions?
+
+Collaboration on this Bit environment happens in [this repository](https://github.com/teambit/envs). Please open an issue or submit pull request there.

--- a/packages/react-native/index.ts
+++ b/packages/react-native/index.ts
@@ -1,0 +1,14 @@
+import 'metro-react-native-babel-preset';
+//@ts-ignore
+import baseCompile from '@bit/bit.envs.internal.babel-base-compiler';
+import Vinyl from 'vinyl';
+
+const compiledFileTypes = ['js'];
+
+const compile = (files: Vinyl[], distPath: string) => {
+  return baseCompile(files, distPath, __dirname, compiledFileTypes);
+};
+
+export default {
+  compile
+};

--- a/packages/react-native/package-lock.json
+++ b/packages/react-native/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "react",
+  "name": "react-native",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -198,18 +198,6 @@
         "lodash": "^4.17.13"
       }
     },
-    "@babel/helper-remap-async-to-generator": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz",
-      "integrity": "sha512-Sk4xmtVdM9sA/jCI80f+KS+Md+ZHIpjuqmYPk1M7F/upHou5e4ReYmExAiu6PVe65BhJPZA2CY9x9k4BqE5klw==",
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.7.4",
-        "@babel/helper-wrap-function": "^7.7.4",
-        "@babel/template": "^7.7.4",
-        "@babel/traverse": "^7.7.4",
-        "@babel/types": "^7.7.4"
-      }
-    },
     "@babel/helper-replace-supers": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz",
@@ -235,17 +223,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
       "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
       "requires": {
-        "@babel/types": "^7.7.4"
-      }
-    },
-    "@babel/helper-wrap-function": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
-      "integrity": "sha512-VsfzZt6wmsocOaVU0OokwrIytHND55yvyT4BPB9AIIgwr8+x7617hetdJTsuGwygN5RC6mxA9EJztTjuwm2ofg==",
-      "requires": {
-        "@babel/helper-function-name": "^7.7.4",
-        "@babel/template": "^7.7.4",
-        "@babel/traverse": "^7.7.4",
         "@babel/types": "^7.7.4"
       }
     },
@@ -275,16 +252,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
       "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw=="
     },
-    "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz",
-      "integrity": "sha512-1ypyZvGRXriY/QP668+s8sFr2mqinhkRDMPSQLNghCQE+GAkFtp+wkHVvg2+Hdki8gwP+NFzJBJ/N1BfzCCDEw==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.7.4",
-        "@babel/plugin-syntax-async-generators": "^7.7.4"
-      }
-    },
     "@babel/plugin-proposal-class-properties": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.7.4.tgz",
@@ -292,15 +259,6 @@
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.7.4",
         "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-proposal-dynamic-import": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.4.tgz",
-      "integrity": "sha512-StH+nGAdO6qDB1l8sZ5UBV8AC3F2VW2I8Vfld73TMKyptMU9DY5YsJAS8U81+vEtxcH3Y/La0wG0btDrhpnhjQ==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.7.4"
       }
     },
     "@babel/plugin-proposal-export-default-from": {
@@ -312,22 +270,13 @@
         "@babel/plugin-syntax-export-default-from": "^7.7.4"
       }
     },
-    "@babel/plugin-proposal-export-namespace-from": {
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
       "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.7.4.tgz",
-      "integrity": "sha512-3whN5U7iZjKdbwRSFwBOjGBgH7apXCzwielljxVH8D/iYcGRqPPw63vlIbG0GqQoT9bO0QYPcIUVkhQG5hcHtg==",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-TbYHmr1Gl1UC7Vo2HVuj/Naci5BEGNZ0AJhzqD2Vpr6QPFWpUmBRLrIDjedzx7/CShq0bRDS2gI4FIs77VHLVQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-export-namespace-from": "^7.7.4"
-      }
-    },
-    "@babel/plugin-proposal-json-strings": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.7.4.tgz",
-      "integrity": "sha512-wQvt3akcBTfLU/wYoqm/ws7YOAQKu8EVJEvHip/mzkNtjaclQoCCIqKXFP5/eyfnfbQCDV3OLRIK3mIVyXuZlw==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-json-strings": "^7.7.4"
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.7.4"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
@@ -357,23 +306,6 @@
         "@babel/plugin-syntax-optional-chaining": "^7.7.4"
       }
     },
-    "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.7.tgz",
-      "integrity": "sha512-80PbkKyORBUVm1fbTLrHpYdJxMThzM1UqFGh0ALEhO9TYbG86Ah9zQYAB/84axz2vcxefDLdZwWwZNlYARlu9w==",
-      "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.7.4",
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-syntax-async-generators": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz",
-      "integrity": "sha512-Li4+EjSpBgxcsmeEF8IFcfV/+yJGxHXDirDkEoyFjumuwbmfCVHUt0HuowD/iGM7OhIRyXJH9YXxqiH6N815+g==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.7.4.tgz",
@@ -390,18 +322,10 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-syntax-export-namespace-from": {
+    "@babel/plugin-syntax-flow": {
       "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.7.4.tgz",
-      "integrity": "sha512-YTc2djwMzJjiTTUJxJunRAnK0xW6OrmCSrgBc7QbWtpUo44FCkhZQtNcwZUqVf3sc4JFxhreiJ/P7YkmCTw4rg==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-syntax-json-strings": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.7.4.tgz",
-      "integrity": "sha512-QpGupahTQW1mHRXddMG5srgpHWqRLwJnJZKXTigB9RPFCCGbDGCgBeM/iC82ICXp414WeYx/tD54w7M2qRqTMg==",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.7.4.tgz",
+      "integrity": "sha512-2AMAWl5PsmM5KPkB22cvOkUyWk6MjUaqhHNU5nSPUl/ns3j5qLfw2SuYP5RbVZ0tfLvePr4zUScbICtDP2CUNw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -410,6 +334,14 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.7.4.tgz",
       "integrity": "sha512-wuy6fiMe9y7HeZBWXYCGt2RGxZOj0BImZ9EyXJVnVGBKO/Br592rbR3rtIQn0eQhAk9vqaKP5n8tVqEFBQMfLg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-XKh/yIRPiQTOeBg0QJjEus5qiSKucKAiApNtO1psqG7D17xmE+X2i5ZqBEuSvo0HRuyPaKaSN/Gy+Ha9KFQolw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -438,10 +370,10 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-syntax-top-level-await": {
+    "@babel/plugin-syntax-typescript": {
       "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.4.tgz",
-      "integrity": "sha512-wdsOw0MvkL1UIgiQ/IFr3ETcfv1xb8RMM0H9wbiDyLaJFyiDg5oZvDLCXosIXmFeIlweML5iOBXAkqddkYNizg==",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.7.4.tgz",
+      "integrity": "sha512-77blgY18Hud4NM1ggTA8xVT/dBENQf17OpiToSa2jSmEY3fWXD2jwrdVlO4kq5yzUTeF15WSQ6b4fByNvJcjpQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -450,24 +382,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.7.4.tgz",
       "integrity": "sha512-zUXy3e8jBNPiffmqkHRNDdZM2r8DWhCB7HhcoyZjiK1TxYEluLHAvQuYnTT+ARqRpabWqy/NHkO6e3MsYB5YfA==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-transform-async-to-generator": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.4.tgz",
-      "integrity": "sha512-zpUTZphp5nHokuy8yLlyafxCJ0rSlFoSHypTUWgpdwoDXWQcseaect7cJ8Ppk6nunOM6+5rPMkod4OYKPR5MUg==",
-      "requires": {
-        "@babel/helper-module-imports": "^7.7.4",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.7.4"
-      }
-    },
-    "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.7.4.tgz",
-      "integrity": "sha512-kqtQzwtKcpPclHYjLK//3lH8OFsCDuDJBaFhVwf8kqdnF6MN4l618UDlcA7TfRs3FayrHj+svYnSX8MC9zmUyQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -512,23 +426,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-transform-dotall-regex": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.7.tgz",
-      "integrity": "sha512-b4in+YlTeE/QmTgrllnb3bHA0HntYvjz8O3Mcbx75UBPJA2xhb5A8nle498VhxSXJHQefjtQxpnLPehDJ4TRlg==",
-      "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.7.4",
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.7.4.tgz",
-      "integrity": "sha512-g1y4/G6xGWMD85Tlft5XedGaZBCIVN+/P0bs6eabmcPP9egFleMAo65OOjlhcz1njpwagyY3t0nsQC9oTFegJA==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
     "@babel/plugin-transform-exponentiation-operator": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.7.4.tgz",
@@ -536,6 +433,15 @@
       "requires": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.7.4",
         "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-flow-strip-types": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.7.4.tgz",
+      "integrity": "sha512-w9dRNlHY5ElNimyMYy0oQowvQpwt/PRHI0QS98ZJCTZU2bvSnKXo5zEiD5u76FBPigTm8TkqzmnUTg16T7qbkA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.7.4"
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -563,24 +469,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-transform-member-expression-literals": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.7.4.tgz",
-      "integrity": "sha512-9VMwMO7i69LHTesL0RdGy93JU6a+qOPuvB4F4d0kR0zyVjJRVJRaoaGjhtki6SzQUu8yen/vxPKN6CWnCUw6bA==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-transform-modules-amd": {
-      "version": "7.7.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.5.tgz",
-      "integrity": "sha512-CT57FG4A2ZUNU1v+HdvDSDrjNWBrtCmSH6YbbgN3Lrf0Di/q/lWRxZrE72p3+HCCz9UjfZOEBdphgC0nzOS6DQ==",
-      "requires": {
-        "@babel/helper-module-transforms": "^7.7.5",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
-      }
-    },
     "@babel/plugin-transform-modules-commonjs": {
       "version": "7.7.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.5.tgz",
@@ -592,48 +480,12 @@
         "babel-plugin-dynamic-import-node": "^2.3.0"
       }
     },
-    "@babel/plugin-transform-modules-systemjs": {
+    "@babel/plugin-transform-object-assign": {
       "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.4.tgz",
-      "integrity": "sha512-y2c96hmcsUi6LrMqvmNDPBBiGCiQu0aYqpHatVVu6kD4mFEXKjyNxd/drc18XXAf9dv7UXjrZwBVmTTGaGP8iw==",
-      "requires": {
-        "@babel/helper-hoist-variables": "^7.7.4",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
-      }
-    },
-    "@babel/plugin-transform-modules-umd": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.4.tgz",
-      "integrity": "sha512-u2B8TIi0qZI4j8q4C51ktfO7E3cQ0qnaXFI1/OXITordD40tt17g/sXqgNNCcMTcBFKrUPcGDx+TBJuZxLx7tw==",
-      "requires": {
-        "@babel/helper-module-transforms": "^7.7.4",
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.4.tgz",
-      "integrity": "sha512-jBUkiqLKvUWpv9GLSuHUFYdmHg0ujC1JEYoZUfeOOfNydZXp1sXObgyPatpcwjWgsdBGsagWW0cdJpX/DO2jMw==",
-      "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.7.4"
-      }
-    },
-    "@babel/plugin-transform-new-target": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.7.4.tgz",
-      "integrity": "sha512-CnPRiNtOG1vRodnsyGX37bHQleHE14B9dnnlgSeEs3ek3fHN1A1SScglTCg1sfbe7sRQ2BUcpgpTpWSfMKz3gg==",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.7.4.tgz",
+      "integrity": "sha512-0TpeUlnhQDwKxPLTIckdaWt46L2s61c/5w5snw1OUod5ehOJywZD98Ha3dFHVjeqkfOFtOTH7cqxddjxUuvcmg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-transform-object-super": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz",
-      "integrity": "sha512-ho+dAEhC2aRnff2JCA0SAK7V2R62zJd/7dmtoe7MHcso4C2mS+vZjn1Pb1pCVZvJs1mgsvv5+7sT+m3Bysb6eg==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.7.4"
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -643,14 +495,6 @@
       "requires": {
         "@babel/helper-call-delegate": "^7.7.4",
         "@babel/helper-get-function-arity": "^7.7.4",
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-transform-property-literals": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.7.4.tgz",
-      "integrity": "sha512-MatJhlC4iHsIskWYyawl53KuHrt+kALSADLQQ/HkhTjX954fkxIEh4q5slL4oRAnsm/eDoZ4q0CIZpcqBuxhJQ==",
-      "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
@@ -672,15 +516,6 @@
         "@babel/plugin-syntax-jsx": "^7.7.4"
       }
     },
-    "@babel/plugin-transform-react-jsx-self": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.7.4.tgz",
-      "integrity": "sha512-PWYjSfqrO273mc1pKCRTIJXyqfc9vWYBax88yIhQb+bpw3XChVC7VWS4VwRVs63wFHKxizvGSd00XEr+YB9Q2A==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.7.4"
-      }
-    },
     "@babel/plugin-transform-react-jsx-source": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.7.4.tgz",
@@ -698,12 +533,15 @@
         "regenerator-transform": "^0.14.0"
       }
     },
-    "@babel/plugin-transform-reserved-words": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.7.4.tgz",
-      "integrity": "sha512-OrPiUB5s5XvkCO1lS7D8ZtHcswIC57j62acAnJZKqGGnHP+TIc/ljQSrgdX/QyOTdEK5COAhuc820Hi1q2UgLQ==",
+    "@babel/plugin-transform-runtime": {
+      "version": "7.7.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.6.tgz",
+      "integrity": "sha512-tajQY+YmXR7JjTwRvwL4HePqoL3DYxpYXIHKVvrOIvJmeHe2y1w4tz5qz9ObUDC9m76rCzIMPyn4eERuwA4a4A==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-module-imports": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -740,12 +578,14 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-transform-typeof-symbol": {
+    "@babel/plugin-transform-typescript": {
       "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.7.4.tgz",
-      "integrity": "sha512-KQPUQ/7mqe2m0B8VecdyaW5XcQYaePyl9R7IsKd+irzj6jvbhoGnRE+M0aNkyAzI07VfUQ9266L5xMARitV3wg==",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.7.4.tgz",
+      "integrity": "sha512-X8e3tcPEKnwwPVG+vP/vSqEShkwODOEeyQGod82qrIuidwIrfnsGn11qPM1jBLF4MqguTXXYzm58d0dY+/wdpg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-create-class-features-plugin": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-typescript": "^7.7.4"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
@@ -755,76 +595,6 @@
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.7.4",
         "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/preset-env": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.7.tgz",
-      "integrity": "sha512-pCu0hrSSDVI7kCVUOdcMNQEbOPJ52E+LrQ14sN8uL2ALfSqePZQlKrOy+tM4uhEdYlCHi4imr8Zz2cZe9oSdIg==",
-      "requires": {
-        "@babel/helper-module-imports": "^7.7.4",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.7.4",
-        "@babel/plugin-proposal-dynamic-import": "^7.7.4",
-        "@babel/plugin-proposal-json-strings": "^7.7.4",
-        "@babel/plugin-proposal-object-rest-spread": "^7.7.7",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.7.7",
-        "@babel/plugin-syntax-async-generators": "^7.7.4",
-        "@babel/plugin-syntax-dynamic-import": "^7.7.4",
-        "@babel/plugin-syntax-json-strings": "^7.7.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.7.4",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.7.4",
-        "@babel/plugin-syntax-top-level-await": "^7.7.4",
-        "@babel/plugin-transform-arrow-functions": "^7.7.4",
-        "@babel/plugin-transform-async-to-generator": "^7.7.4",
-        "@babel/plugin-transform-block-scoped-functions": "^7.7.4",
-        "@babel/plugin-transform-block-scoping": "^7.7.4",
-        "@babel/plugin-transform-classes": "^7.7.4",
-        "@babel/plugin-transform-computed-properties": "^7.7.4",
-        "@babel/plugin-transform-destructuring": "^7.7.4",
-        "@babel/plugin-transform-dotall-regex": "^7.7.7",
-        "@babel/plugin-transform-duplicate-keys": "^7.7.4",
-        "@babel/plugin-transform-exponentiation-operator": "^7.7.4",
-        "@babel/plugin-transform-for-of": "^7.7.4",
-        "@babel/plugin-transform-function-name": "^7.7.4",
-        "@babel/plugin-transform-literals": "^7.7.4",
-        "@babel/plugin-transform-member-expression-literals": "^7.7.4",
-        "@babel/plugin-transform-modules-amd": "^7.7.5",
-        "@babel/plugin-transform-modules-commonjs": "^7.7.5",
-        "@babel/plugin-transform-modules-systemjs": "^7.7.4",
-        "@babel/plugin-transform-modules-umd": "^7.7.4",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
-        "@babel/plugin-transform-new-target": "^7.7.4",
-        "@babel/plugin-transform-object-super": "^7.7.4",
-        "@babel/plugin-transform-parameters": "^7.7.7",
-        "@babel/plugin-transform-property-literals": "^7.7.4",
-        "@babel/plugin-transform-regenerator": "^7.7.5",
-        "@babel/plugin-transform-reserved-words": "^7.7.4",
-        "@babel/plugin-transform-shorthand-properties": "^7.7.4",
-        "@babel/plugin-transform-spread": "^7.7.4",
-        "@babel/plugin-transform-sticky-regex": "^7.7.4",
-        "@babel/plugin-transform-template-literals": "^7.7.4",
-        "@babel/plugin-transform-typeof-symbol": "^7.7.4",
-        "@babel/plugin-transform-unicode-regex": "^7.7.4",
-        "@babel/types": "^7.7.4",
-        "browserslist": "^4.6.0",
-        "core-js-compat": "^3.6.0",
-        "invariant": "^2.2.2",
-        "js-levenshtein": "^1.1.3",
-        "semver": "^5.5.0"
-      }
-    },
-    "@babel/preset-react": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.7.4.tgz",
-      "integrity": "sha512-j+vZtg0/8pQr1H8wKoaJyGL2IEk3rG/GIvua7Sec7meXVIvGycihlGMx5xcU00kqCJbwzHs18xTu3YfREOqQ+g==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-transform-react-display-name": "^7.7.4",
-        "@babel/plugin-transform-react-jsx": "^7.7.4",
-        "@babel/plugin-transform-react-jsx-self": "^7.7.4",
-        "@babel/plugin-transform-react-jsx-source": "^7.7.4"
       }
     },
     "@babel/runtime": {
@@ -1078,12 +848,14 @@
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
     },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
       "requires": {
         "@types/events": "*",
         "@types/minimatch": "*",
@@ -1093,17 +865,20 @@
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
     },
     "@types/node": {
       "version": "12.12.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.21.tgz",
-      "integrity": "sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA=="
+      "integrity": "sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==",
+      "dev": true
     },
     "@types/rimraf": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.3.tgz",
       "integrity": "sha512-dZfyfL/u9l/oi984hEXdmAjX3JHry7TLWw43u1HQ8HhPv6KtfxnrZ3T/bleJ0GEvnk9t5sM7eePkgMqz3yBcGg==",
+      "dev": true,
       "requires": {
         "@types/glob": "*",
         "@types/node": "*"
@@ -1841,16 +1616,6 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
-    "browserslist": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-      "integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
-      "requires": {
-        "caniuse-lite": "^1.0.30001015",
-        "electron-to-chromium": "^1.3.322",
-        "node-releases": "^1.1.42"
-      }
-    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -1931,11 +1696,6 @@
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-1.0.1.tgz",
       "integrity": "sha1-FXxCOCZfXPlKHf/ehkRlUsvz9wU=",
       "dev": true
-    },
-    "caniuse-lite": {
-      "version": "1.0.30001016",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-      "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -2289,22 +2049,6 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
       "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
       "dev": true
-    },
-    "core-js-compat": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.0.tgz",
-      "integrity": "sha512-Z3eCNjGgoYluH89Jt4wVkfYsc/VdLrA2/woX5lm0isO/pCT+P+Y+o65bOuEnjDJLthdwTBxbCVzptTXtc18fJg==",
-      "requires": {
-        "browserslist": "^4.8.2",
-        "semver": "7.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
-        }
-      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3685,11 +3429,6 @@
         "safer-buffer": "^2.1.0"
       }
     },
-    "electron-to-chromium": {
-      "version": "1.3.322",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
-      "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA=="
-    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -4997,14 +4736,6 @@
         }
       }
     },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -5396,11 +5127,6 @@
       "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
       "dev": true
     },
-    "js-levenshtein": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
-    },
     "js-message": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.5.tgz",
@@ -5716,14 +5442,6 @@
         "triple-beam": "^1.3.0"
       }
     },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -5918,6 +5636,48 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "metro-react-native-babel-preset": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.57.0.tgz",
+      "integrity": "sha512-pvLh1QOwdxsjgYE2a+4aTKs3LSF3+t4jscxHtkND6wsJnKVVspLt8FkDaORa6zr3Fq12tVpEt5NJMdgtWqBpaA==",
+      "requires": {
+        "@babel/plugin-proposal-class-properties": "^7.0.0",
+        "@babel/plugin-proposal-export-default-from": "^7.0.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+        "@babel/plugin-syntax-export-default-from": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.2.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.0.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.0.0",
+        "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+        "@babel/plugin-transform-for-of": "^7.0.0",
+        "@babel/plugin-transform-function-name": "^7.0.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+        "@babel/plugin-transform-object-assign": "^7.0.0",
+        "@babel/plugin-transform-parameters": "^7.0.0",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-source": "^7.0.0",
+        "@babel/plugin-transform-regenerator": "^7.0.0",
+        "@babel/plugin-transform-runtime": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-sticky-regex": "^7.0.0",
+        "@babel/plugin-transform-template-literals": "^7.0.0",
+        "@babel/plugin-transform-typescript": "^7.0.0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "react-refresh": "^0.4.0"
+      }
     },
     "micromatch": {
       "version": "2.3.11",
@@ -6347,21 +6107,6 @@
         "event-pubsub": "4.3.0",
         "js-message": "1.0.5",
         "js-queue": "2.0.0"
-      }
-    },
-    "node-releases": {
-      "version": "1.1.43",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.43.tgz",
-      "integrity": "sha512-Rmfnj52WNhvr83MvuAWHEqXVoZXCcDQssSOffU4n4XOL9sPrP61mSZ88g25NqmABDvH7PiAlFCzoSCSdzA293w==",
-      "requires": {
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
       }
     },
     "node-source-walk": {
@@ -7205,8 +6950,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-platform": {
       "version": "0.11.15",
@@ -7589,6 +7333,11 @@
         }
       }
     },
+    "react-refresh": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.2.tgz",
+      "integrity": "sha512-kv5QlFFSZWo7OlJFNYbxRtY66JImuP2LcrFgyJfQaf85gSP+byzG21UbDQEYjU7f//ny8rwiEkO6py2Y+fEgAQ=="
+    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -7913,7 +7662,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
       "integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "react-native",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+        "test": "cpx \".babelrc\" dist && node node_modules/.bin/mocha dist/test/*.spec.js",
+        "test:hero": "run-s clean build test",
+        "build": "tsc",
+        "clean": "rm -rf dist types"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "dependencies": {
+        "metro-react-native-babel-preset": "^0.57.0",
+        "rimraf": "^3.0.0"
+    },
+    "devDependencies": {
+        "@bit/bit.envs.common.build-component": "0.0.11",
+        "@types/chai": "^4.2.5",
+        "@types/rimraf": "^2.0.3",
+        "bit-bin": "^14.7.1",
+        "chai": "^4.2.0",
+        "cpx": "^1.5.0"
+    }
+}

--- a/packages/react-native/test/compile-react.spec.ts
+++ b/packages/react-native/test/compile-react.spec.ts
@@ -1,0 +1,35 @@
+import Helper from 'bit-bin/dist/e2e-helper/e2e-helper';
+import { expect } from 'chai';
+import rimraf = require('rimraf');
+import { buildComponentInWorkspace, BuildResult } from '@bit/bit.envs.common.build-component';
+import { NormalButtonComponent, CardComponent, InputComponent } from './component-examples';
+
+describe('babel react-native', () => {
+  const helper = new Helper();
+  let results: BuildResult = {
+    directory: '',
+    files: [],
+    showComponent: {}
+  };
+  before(async function() {
+    this.timeout(1000 * 10 * 10);
+    results = await buildComponentInWorkspace(helper, {
+      compilerPath: 'dist/index.js',
+      envTester: 'dist/index.js',
+      component: {
+        'src/comp.js': NormalButtonComponent,
+        'src/card.js': CardComponent,
+        'src/input.js': InputComponent,
+        'src/func.js': '',
+        'src/test.css': '',
+        'src/try.svg': ''
+      }
+    });
+  });
+  after(async function() {
+    if (results.directory) {
+      return new Promise((resolve, reject) => rimraf(results.directory, {}, error => (error ? reject() : resolve())));
+    }
+  });
+  it('build should pass', async function() {});
+});

--- a/packages/react-native/test/component-examples.ts
+++ b/packages/react-native/test/component-examples.ts
@@ -1,0 +1,436 @@
+const NormalButtonComponent: string = `
+import React, { Component } from 'react';
+import PropTypes from 'prop-types'; // ES6
+import { StyleSheet } from 'react-native';
+import { Button } from 'react-native-elements';
+
+class NormalButton extends Component {
+  render() {
+    const { text, backgroundColor, width, height, style } = this.props;
+    return (
+      <Button
+        title={text.toUpperCase()}
+        raised={true}
+        onPress={() => this.props.onPress?.()}
+        buttonStyle={{
+          height,
+          width,
+          //borderRadius: width * 2,
+          //backgroundColor,
+          ...style,
+        }}
+      />
+    );
+  }
+}
+
+NormalButton.propTypes = {
+  text: PropTypes.string,
+  backgroundColor: PropTypes.string,
+  width: PropTypes.number,
+  height: PropTypes.number,
+  onPress: PropTypes.func,
+  style: PropTypes.object,
+};
+
+NormalButton.defaultProps = {
+  text: 'Button',
+  backgroundColor: '#fafafa',
+  width: 120,
+  height: 50,
+  style: {},
+};
+
+export default NormalButton;
+`;
+
+const CardComponent: string = `
+import React, { Component } from 'react';
+import PropTypes from 'prop-types'; // ES6
+import { StyleSheet, Text, View, TouchableWithoutFeedback, Animated, Image } from 'react-native';
+import backCardImage from '../assets/images/carte-dos-2.png';
+
+class Card extends Component {
+  getColor = suit => {
+    if (suit === 'spades' || suit === 'clubs') {
+      return styles.black;
+    } else {
+      return styles.red;
+    }
+  };
+
+  getSuitSymbol = suit => {
+    /*
+     * spades ♠
+     * clubs ♣
+     * diamonds ♦
+     * hearts ♥
+     */
+    switch (suit) {
+      case 'spades':
+        return '♠';
+        break;
+      case 'clubs':
+        return '♣';
+        break;
+      case 'diamonds':
+        return '♦';
+        break;
+      case 'hearts':
+        return '♥';
+        break;
+      default:
+        return '';
+        break;
+    }
+  };
+
+  UNSAFE_componentWillMount() {
+    const hiddenValue = this.props.hidden ? 180 : 0;
+    this.animatedValue = new Animated.Value(hiddenValue);
+    this.value = hiddenValue;
+    this.animatedValue.addListener(({ value }) => {
+      this.value = value;
+    });
+    this.frontInterpolate = this.animatedValue.interpolate({
+      inputRange: [0, 180],
+      outputRange: ['0deg', '180deg'],
+    });
+    this.backInterpolate = this.animatedValue.interpolate({
+      inputRange: [0, 180],
+      outputRange: ['180deg', '360deg'],
+    });
+  }
+
+  flipCard() {
+    if (this.value >= 90) {
+      Animated.spring(this.animatedValue, {
+        toValue: 0,
+        friction: 8,
+        tension: 10,
+      }).start();
+    } else {
+      Animated.spring(this.animatedValue, {
+        toValue: 180,
+        friction: 8,
+        tension: 10,
+      }).start();
+    }
+  }
+
+  render() {
+    const frontAnimatedStyle = {
+      transform: [{ rotateY: this.frontInterpolate }],
+    };
+    const backAnimatedStyle = {
+      transform: [{ rotateY: this.backInterpolate }],
+    };
+    const { value, suit, hidden, style } = this.props;
+    const color = this.getColor(suit);
+    return (
+      <TouchableWithoutFeedback onPress={() => this.flipCard()}>
+        <View style={[styles.card, style]}>
+          <Animated.View style={[styles.flipCard, styles.flipCardFront, frontAnimatedStyle]}>
+            <Text style={[styles.valueText, color]}>{value}</Text>
+            <Text style={[styles.suitText, color]}>{this.getSuitSymbol(suit)}</Text>
+          </Animated.View>
+          <Animated.View style={[styles.flipCard, styles.flipCardBack, backAnimatedStyle]}>
+            <Image source={backCardImage} style={styles.backImage} />
+          </Animated.View>
+        </View>
+      </TouchableWithoutFeedback>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  card: {
+    width: 85,
+    height: 103.85,
+    shadowColor: 'black',
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.8,
+    shadowRadius: 2,
+  },
+  flipCard: {
+    width: 85,
+    height: 103.85,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backfaceVisibility: 'hidden',
+    borderRadius: 8,
+  },
+  flipCardFront: {
+    backgroundColor: 'white',
+  },
+  flipCardBack: {
+    position: 'absolute',
+    top: 0,
+  },
+  backImage: {
+    width: '100%',
+    height: '100%',
+  },
+  suitText: {
+    fontSize: 62,
+    position: 'absolute',
+    bottom: 0,
+  },
+  valueText: {
+    position: 'absolute',
+    top: 5,
+    left: 8,
+    fontSize: 28,
+    fontWeight: 'bold',
+    textAlign: 'left',
+  },
+  black: {
+    color: 'black',
+  },
+  red: {
+    color: 'red',
+  },
+});
+
+Card.propTypes = {
+  value: PropTypes.string.isRequired,
+  suit: PropTypes.string.isRequired,
+  hidden: PropTypes.bool,
+  style: PropTypes.object,
+};
+
+Card.defaultProps = {
+  hidden: false,
+  style: {},
+};
+
+export default Card;
+`;
+
+const InputComponent: string = `
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Text,
+  View,
+  TextInput,
+  Animated,
+  Easing,
+  Platform,
+  StyleSheet,
+} from 'react-native';
+
+import { nodeType, renderNode, patchWebProps } from '../helpers';
+import { fonts, withTheme, ViewPropTypes, TextPropTypes } from '../config';
+
+import Icon from '../icons/Icon';
+
+const renderText = (content, defaultProps, style) =>
+  renderNode(Text, content, {
+    ...defaultProps,
+    style: StyleSheet.flatten([style, defaultProps && defaultProps.style]),
+  });
+
+class Input extends React.Component {
+  shakeAnimationValue = new Animated.Value(0);
+
+  focus() {
+    this.input.focus();
+  }
+
+  blur() {
+    this.input.blur();
+  }
+
+  clear() {
+    this.input.clear();
+  }
+
+  isFocused() {
+    return this.input.isFocused();
+  }
+
+  setNativeProps(nativeProps) {
+    this.input.setNativeProps(nativeProps);
+  }
+
+  shake = () => {
+    const { shakeAnimationValue } = this;
+
+    shakeAnimationValue.setValue(0);
+    // Animation duration based on Material Design
+    // https://material.io/guidelines/motion/duration-easing.html#duration-easing-common-durations
+    Animated.timing(shakeAnimationValue, {
+      duration: 375,
+      toValue: 3,
+      ease: Easing.bounce,
+    }).start();
+  };
+
+  render() {
+    const {
+      containerStyle,
+      disabled,
+      disabledInputStyle,
+      inputContainerStyle,
+      leftIcon,
+      leftIconContainerStyle,
+      rightIcon,
+      rightIconContainerStyle,
+      inputComponent: InputComponent = TextInput,
+      inputStyle,
+      errorProps,
+      errorStyle,
+      errorMessage,
+      label,
+      labelStyle,
+      labelProps,
+      theme,
+      ...attributes
+    } = this.props;
+
+    const translateX = this.shakeAnimationValue.interpolate({
+      inputRange: [0, 0.5, 1, 1.5, 2, 2.5, 3],
+      outputRange: [0, -15, 0, 15, 0, -15, 0],
+    });
+
+    return (
+      <View style={StyleSheet.flatten([styles.container, containerStyle])}>
+        {renderText(
+          label,
+          { style: labelStyle, ...labelProps },
+          styles.label(theme)
+        )}
+
+        <Animated.View
+          style={StyleSheet.flatten([
+            styles.inputContainer(theme),
+            inputContainerStyle,
+            { transform: [{ translateX }] },
+          ])}
+        >
+          {leftIcon && (
+            <View
+              style={StyleSheet.flatten([
+                styles.iconContainer,
+                leftIconContainerStyle,
+              ])}
+            >
+              {renderNode(Icon, leftIcon)}
+            </View>
+          )}
+
+          <InputComponent
+            testID="RNE__Input__text-input"
+            underlineColorAndroid="transparent"
+            editable={!disabled}
+            {...patchWebProps(attributes)}
+            ref={ref => {
+              this.input = ref;
+            }}
+            style={StyleSheet.flatten([
+              styles.input,
+              inputStyle,
+              disabled && styles.disabledInput,
+              disabled && disabledInputStyle,
+            ])}
+          />
+
+          {rightIcon && (
+            <View
+              style={StyleSheet.flatten([
+                styles.iconContainer,
+                rightIconContainerStyle,
+              ])}
+            >
+              {renderNode(Icon, rightIcon)}
+            </View>
+          )}
+        </Animated.View>
+
+        {!!errorMessage && (
+          <Text
+            {...errorProps}
+            style={StyleSheet.flatten([
+              styles.error(theme),
+              errorStyle && errorStyle,
+            ])}
+          >
+            {errorMessage}
+          </Text>
+        )}
+      </View>
+    );
+  }
+}
+
+Input.propTypes = {
+  containerStyle: ViewPropTypes.style,
+  disabled: PropTypes.bool,
+  disabledInputStyle: TextPropTypes.style,
+  inputContainerStyle: ViewPropTypes.style,
+  leftIcon: nodeType,
+  leftIconContainerStyle: ViewPropTypes.style,
+  rightIcon: nodeType,
+  rightIconContainerStyle: ViewPropTypes.style,
+  inputStyle: TextPropTypes.style,
+  inputComponent: PropTypes.elementType,
+  errorProps: PropTypes.object,
+  errorStyle: TextPropTypes.style,
+  errorMessage: PropTypes.string,
+  label: PropTypes.node,
+  labelStyle: TextPropTypes.style,
+  labelProps: PropTypes.object,
+  theme: PropTypes.object,
+};
+
+const styles = {
+  container: {
+    width: '100%',
+    paddingHorizontal: 10,
+  },
+  disabledInput: {
+    opacity: 0.5,
+  },
+  inputContainer: theme => ({
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+    alignItems: 'center',
+    borderColor: theme.colors.grey3,
+  }),
+  iconContainer: {
+    height: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginLeft: 15,
+  },
+  input: {
+    alignSelf: 'center',
+    color: 'black',
+    fontSize: 18,
+    flex: 1,
+    minHeight: 40,
+  },
+  error: theme => ({
+    margin: 5,
+    fontSize: 12,
+    color: theme.colors.error,
+  }),
+  label: theme => ({
+    fontSize: 16,
+    color: theme.colors.grey3,
+    ...Platform.select({
+      android: {
+        ...fonts.android.bold,
+      },
+      default: {
+        fontWeight: 'bold',
+      },
+    }),
+  }),
+};
+
+export { Input };
+export default withTheme(Input, 'Input');
+`;
+export { NormalButtonComponent, CardComponent, InputComponent };

--- a/packages/react-native/tsconfig.json
+++ b/packages/react-native/tsconfig.json
@@ -1,0 +1,64 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "skipLibCheck": true,
+    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./dist" /* Redirect output structure to the directory. */,
+    "rootDir": "./" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
+    // "composite": true,                     /* Enable project compilation */
+    // "incremental": true,                   /* Enable incremental compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    "noEmitOnError": false,
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    "inlineSourceMap": true /* Emit a single file with source maps instead of having a separate file. */,
+    "inlineSources": true /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  },
+  "exclude": ["fixtures/**/*", "dist/**/*"]
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,6 +27,7 @@
     "@bit/bit.envs.common.build-component": "0.0.11",
     "@bit/bit.envs.common.create-workspace": "0.0.4",
     "@types/chai": "^4.2.5",
+    "bit-bin": "^14.7.1",
     "chai": "^4.2.0",
     "cpx": "^1.5.0"
   }


### PR DESCRIPTION
## Proposed Changes

- Add ReactNative compiler with test.
- Fix `bit-bin` to be peer dependencies for `react` and `react-native` compilers.
- Update `.taskfile` to run `react-native` test.
- Export a new version of `react` and `react-native` compilers.
