### PR TITLE
Remove ts-ignore in React and ReactNative compilers

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -128,7 +128,7 @@
         "origin": "AUTHORED",
         "exported": true
     },
-    "bit.envs/compilers/react-native@0.0.3": {
+    "bit.envs/compilers/react-native@0.0.4": {
         "files": [
             {
                 "relativePath": "packages/react-native/.babelrc",
@@ -219,7 +219,7 @@
         "origin": "AUTHORED",
         "exported": true
     },
-    "bit.envs/compilers/react@1.0.9": {
+    "bit.envs/compilers/react@1.0.10": {
         "files": [
             {
                 "relativePath": "packages/react/.babelrc",

--- a/packages/react-native/index.ts
+++ b/packages/react-native/index.ts
@@ -1,8 +1,7 @@
 import 'metro-react-native-babel-preset';
-//@ts-ignore
-import baseCompile from '@bit/bit.envs.internal.babel-base-compiler';
 import Vinyl from 'vinyl';
 
+const baseCompile = require('@bit/bit.envs.internal.babel-base-compiler');
 const compiledFileTypes = ['js'];
 
 const compile = (files: Vinyl[], distPath: string) => {

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -5,10 +5,9 @@ import '@babel/plugin-proposal-export-default-from';
 import '@babel/plugin-proposal-export-namespace-from';
 import '@babel/plugin-proposal-object-rest-spread';
 import '@babel/plugin-proposal-optional-chaining';
-//@ts-ignore
-import baseCompile from '@bit/bit.envs.internal.babel-base-compiler';
 import Vinyl from 'vinyl';
 
+const baseCompile = require('@bit/bit.envs.internal.babel-base-compiler');
 const compiledFileTypes = ['js', 'jsx'];
 
 const compile = (files: Vinyl[], distPath: string) => {


### PR DESCRIPTION
## Proposed Changes

- Remove ts-ignore and use require instead of import.
