### PR TITLE
angular compiler fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ notes/
 dist/
 .vscode
 .history
+.idea

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -17,8 +17,8 @@ import * as fs from 'fs';
 import { TSConfig } from './tsconfig';
 
 import {
-  CompilerContext,
   BuildResults,
+  CompilerContext,
   createCapsule,
   destroyCapsule,
   getTestFiles,
@@ -35,7 +35,21 @@ const DEV_DEPS = {
   '@angular/core': '>= 8.0.0',
   '@angular/common': '>= 8.0.0',
 };
-const PKG_JSON_KEYS = ['es2015', 'esm5', 'esm2015', 'fesm5', 'fesm2015', 'module', 'typings'];
+
+const PKG_JSON_KEYS = [
+  'es2015_ivy_ngcc',
+  'es2015',
+  'esm5',
+  'esm2015',
+  'fesm5',
+  'fesm2015_ivy_ngcc',
+  'fesm2015',
+  'module',
+  'typings',
+  'metadata',
+];
+
+const DIST_DIRECTORY = 'dist';
 
 export function getDynamicPackageDependencies(): Record<string, any> {
   return {
@@ -47,6 +61,7 @@ function escapeRegExp(input: string): string {
   return input.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
+
 export async function action(ctx: CompilerContext): Promise<BuildResults> {
   // build capsule
 
@@ -54,10 +69,9 @@ export async function action(ctx: CompilerContext): Promise<BuildResults> {
   const distDir = path.join(directory, 'dist');
 
   const componentObject = res.componentWithDependencies.component.toObject();
-  console.log(res.componentWithDependencies);
   const { files, mainFile } = componentObject;
 
-  debug(`Building capsule in ${directory}`);
+  debug(`Building capsule in ${ directory }`);
 
   // create tsconfig.json
   let tests: Vinyl[] = getTestFiles(files, []);
@@ -103,7 +117,9 @@ export async function action(ctx: CompilerContext): Promise<BuildResults> {
   const pkgJsonContent = require(path.resolve(distDir, 'package.json'));
   const packageJson: Record<string, any> = {};
   PKG_JSON_KEYS.forEach((k: string): void => {
-    packageJson[k] = pkgJsonContent[k];
+    if (k in pkgJsonContent) {
+      packageJson[k] = path.join(DIST_DIRECTORY, pkgJsonContent[k]);
+    }
   });
   destroyCapsule(res.capsule);
 

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -43,6 +43,10 @@ export function getDynamicPackageDependencies(): Record<string, any> {
   };
 }
 
+function escapeRegExp(input: string): string {
+  return input.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
 export async function action(ctx: CompilerContext): Promise<BuildResults> {
   // build capsule
 
@@ -71,7 +75,11 @@ export async function action(ctx: CompilerContext): Promise<BuildResults> {
     lib: {
       entryFile: mainFile,
     },
-    whitelistedNonPeerDependencies: [...Object.keys(DEV_DEPS), ...Object.keys(componentObject.packageDependencies)],
+    whitelistedNonPeerDependencies: [
+      ...Object.keys(DEV_DEPS).map(escapeRegExp),
+      ...Object.keys(componentObject.packageDependencies).map(escapeRegExp),
+      escapeRegExp('@bit'), // ...bitDependencies
+    ],
   };
   if (!fs.existsSync(ngPackageFile)) {
     fs.writeFileSync(ngPackageFile, JSON.stringify(ngPackage, null, 4));


### PR DESCRIPTION
- properly escape whitelistedNonPeerDependencies,
- add '@bit' to allow importing other '@bit' components when  building

